### PR TITLE
fix: defend xss attack at jsonp mode

### DIFF
--- a/lib/jsonp.js
+++ b/lib/jsonp.js
@@ -9,6 +9,12 @@
 const JSONPStream = require('./jsonp-stream')
 
 const SAFTY_CALLBACK_REG = /^[0-9a-zA-Z_]+$/
+const TPL_OF_501 = `<html>
+<head><title>501 Not Implemented</title></head>
+<body bgcolor="white">
+<center><h1>501 Not Implemented</h1></center>
+</body>
+</html>`
 
 module.exports = function jsonp (options) {
   options = options || {}
@@ -32,6 +38,8 @@ module.exports = function jsonp (options) {
 
     if (!SAFTY_CALLBACK_REG.test(callback)) {
       this.response.status = 501
+      this.body = TPL_OF_501
+      this.type = 'html'
       return
     }
 

--- a/lib/jsonp.js
+++ b/lib/jsonp.js
@@ -8,6 +8,8 @@
 
 const JSONPStream = require('./jsonp-stream')
 
+const SAFTY_CALLBACK_REG = /^[0-9a-zA-Z_]+$/
+
 module.exports = function jsonp (options) {
   options = options || {}
 
@@ -27,6 +29,14 @@ module.exports = function jsonp (options) {
 
     if (!callback) return
     if (this.body == null) return
+
+    if (!SAFTY_CALLBACK_REG.test(callback)) {
+      this.response.status = 501
+      return
+    }
+
+    // IE bowser would ignore content-type header in some case
+    this.set('X-Content-Type-Options', 'nosniff')
 
     if (this.method === 'POST') {
       this.type = 'html'

--- a/lib/jsonp.js
+++ b/lib/jsonp.js
@@ -8,13 +8,23 @@
 
 const JSONPStream = require('./jsonp-stream')
 
-const SAFTY_CALLBACK_REG = /^[0-9a-zA-Z_]+$/
+const SPECIAL_CALLBACK_KEY = ['(', ')', '&', '<', '>', '\'', '"', '/']
 const TPL_OF_501 = `<html>
 <head><title>501 Not Implemented</title></head>
 <body bgcolor="white">
 <center><h1>501 Not Implemented</h1></center>
 </body>
 </html>`
+
+/**
+ * check the safty of callback name
+ * @param {String} name
+ */
+function isCallbackSafty (name) {
+  return !SPECIAL_CALLBACK_KEY.some((key) => {
+    return name.indexOf(key) > -1
+  })
+}
 
 module.exports = function jsonp (options) {
   options = options || {}
@@ -36,7 +46,7 @@ module.exports = function jsonp (options) {
     if (!callback) return
     if (this.body == null) return
 
-    if (!SAFTY_CALLBACK_REG.test(callback)) {
+    if (!isCallbackSafty(callback)) {
       this.response.status = 501
       this.body = TPL_OF_501
       this.type = 'html'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-jsonp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "JSONP middleware with GET/POST support for koajs",
   "main": "index.js",
   "scripts": {

--- a/test/jsonp.test.js
+++ b/test/jsonp.test.js
@@ -113,7 +113,7 @@ describe('jsonp()', function () {
     })
   })
 
-  it('should block the JSONP mode when callback is not safe', function (done) {
+  it('should block the JSONP mode when callback is not safty', function (done) {
     get('http://localhost:3000/buffered?my_cb_name=eval(alert(123));', function (err, res, body) {
       assert.equal(res.statusCode, 501)
       done(err)

--- a/test/jsonp.test.js
+++ b/test/jsonp.test.js
@@ -78,6 +78,7 @@ describe('jsonp()', function () {
       var data = JSON.parse(body.match(/cb\(([^)]+)\)/m)[1])
       assert.equal(data.foo, 'bar')
       assert.equal(res.headers['content-type'], 'text/javascript; charset=utf-8')
+      assert.equal(res.headers['x-content-type-options'], 'nosniff')
       done(err)
     })
   })
@@ -88,6 +89,7 @@ describe('jsonp()', function () {
       assert.equal(data.foo, 'bar')
       assert.match(body, /<!doctype html>/)
       assert.equal(res.headers['content-type'], 'text/html; charset=utf-8')
+      assert.equal(res.headers['x-content-type-options'], 'nosniff')
       done(err)
     })
   })
@@ -107,6 +109,13 @@ describe('jsonp()', function () {
       assert.lengthOf(data, 5)
       assert.match(body, /<!doctype html>/)
       assert.equal(res.headers['content-type'], 'text/html; charset=utf-8')
+      done(err)
+    })
+  })
+
+  it('should block the JSONP mode when callback is not safe', function (done) {
+    get('http://localhost:3000/buffered?my_cb_name=eval(alert(123));', function (err, res, body) {
+      assert.equal(res.statusCode, 501)
       done(err)
     })
   })


### PR DESCRIPTION
Parameter callback exists reflection-XSS.
Hackers can use this vulnerability to execute arbitrary HTML / JS code, which can lead to the following hazards: stealing user cookie information, spreading worms, etc.